### PR TITLE
feat: Remove the need for call to external API (wip)

### DIFF
--- a/watch/domain/Cargo.toml
+++ b/watch/domain/Cargo.toml
@@ -20,6 +20,7 @@ version = "1.38.0"
 features = [ "macros", "rt", "rt-multi-thread", "time", "sync" ]
 
 [dependencies]
+whois = "2.0"
 aok = "0.1.12"
 genv = "0.1.10"
 static_init = "1.0.3"

--- a/watch/domain/src/whois.rs
+++ b/watch/domain/src/whois.rs
@@ -2,6 +2,8 @@ use aok::Result;
 use reqwest::Client;
 use sonic_rs::{from_str, Deserialize};
 use str2ts::str2ts;
+use whois::WhoIs;
+use whois::WhoIsLookupOptions;
 
 pub const NOT_FREE: [&str; 3] = ["ua", "top", "org"];
 
@@ -31,32 +33,49 @@ impl Whois {
     Whois { token }
   }
 
-  pub async fn expire_as93(&self, host: &str) -> Result<u64> {
-    let response = reqwest::get("https://who-dat.as93.net/".to_owned() + host)
-      .await?
-      .text()
-      .await?;
+    async fn expire_whois_lookup(&self, host: &str) -> Result<u64> {
+        // Perform a native WHOIS lookup
+        let whois = WhoIs::from_string("")?;
+        let result = whois.lookup(WhoIsLookupOptions::from_string(host))?;
 
-    let json: WhoisAs93 = sonic_rs::from_str(&response)?;
-    Ok(str2ts(&json.domain.expiration_date_in_time)?)
-  }
+        // Attempt to find an expiration line in the result.
+        // We'll look for a line starting with 'Expiration' or 'Expiry' and parse it.
+        let mut expiration_line = None;
+        for line in result.lines() {
+            if line.to_lowercase().contains("expir") {
+                expiration_line = Some(line.trim().to_string());
+                break;
+            }
+        }
 
-  pub async fn expire_whoisjson(&self, host: &str) -> Result<u64> {
-    let url = "https://whoisjson.com/api/v1/whois?domain=".to_owned() + host;
+        // If we found an expiration line, try to extract a date
+        // We'll attempt to parse the whole line with str2ts directly,
+        // assuming it can handle common date formats. If not, you'll need to
+        // parse/format the date string more carefully.
+        if let Some(line) = expiration_line {
+            // Often WHOIS expiration lines look like: "Expiration Date: YYYY-MM-DD"
+            // Let's try to extract the date portion.
+            // We'll split by spaces and try each token with str2ts.
+            for token in line.split_whitespace() {
+                if let Ok(ts) = str2ts(token) {
+                    return Ok(ts);
+                }
+            }
+        }
 
-    let client = Client::new();
-    let response = client
-      .get(url)
-      .header("Authorization", &self.token)
-      .send()
-      .await?
-      .text()
-      .await?;
+        // If we cannot find or parse expiration date, return an error
+        Err("Could not parse expiration date".into())
+    }
 
-    let whois_response: WhoisJson = from_str(&response)?;
+    pub async fn expire_as93(&self, host: &str) -> Result<u64> {
+        // Previously called external API, now replaced with local WHOIS lookup
+        self.expire_whois_lookup(host).await
+    }
 
-    Ok(str2ts(&whois_response.expires)?)
-  }
+    pub async fn expire_whoisjson(&self, host: &str) -> Result<u64> {
+        // Previously called external API, now replaced with local WHOIS lookup
+        self.expire_whois_lookup(host).await
+    }
 }
 
 #[derive(Debug)]
@@ -66,13 +85,13 @@ pub struct Domain {
 }
 
 impl Domain {
-  pub async fn expire(&self, whois: &Whois) -> Result<u64> {
-    if self.free {
-      whois.expire_as93(&self.host).await
-    } else {
-      whois.expire_whoisjson(&self.host).await
+    pub async fn expire(&self, whois: &Whois) -> Result<u64> {
+        if self.free {
+            whois.expire_as93(&self.host).await
+        } else {
+            whois.expire_whoisjson(&self.host).await
+        }
     }
-  }
 
   pub fn new(host: impl Into<String>) -> Self {
     let host = host.into();


### PR DESCRIPTION
Heya,

I'm the owner of who-dat.as93.net (the whois service you're using). And due to excess traffic which has increased by compute bill quite a lot the past few months, I am going to implement auth. So you'll need to either self-host your own instance, or better yet just make whois requests directly from your server.

I've submitted this PR as a proof of concept, and to let you know in advance that you'll loose access to my api.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for local WHOIS lookups to determine expiration dates.
  - Added a dependency for enhanced WHOIS functionality.

- **Bug Fixes**
  - Improved error handling for expiration date parsing from WHOIS results.

- **Refactor**
  - Simplified the control flow by removing external API dependencies for expiration date retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->